### PR TITLE
Fix issue with PIC not using primary osc.

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,7 +1,5 @@
-#ifndef CONFIG_H
-#define	CONFIG_H
 
-// DSPIC33EP256GP502 Configuration Bit Settings
+// DSPIC33EP128GP502 Configuration Bit Settings
 
 // 'C' source line config statements
 
@@ -28,7 +26,7 @@
 #pragma config FCKSM = CSECMD           // Clock Switching Mode bits (Clock switching is enabled,Fail-safe Clock Monitor is disabled)
 
 // FOSCSEL
-#pragma config FNOSC = FRCDIVN          // Oscillator Source Selection (Internal Fast RC (FRC) Oscillator with postscaler)
+#pragma config FNOSC = PRIPLL           // Oscillator Source Selection (Primary Oscillator with PLL module (XT + PLL, HS + PLL, EC + PLL))
 #pragma config IESO = ON                // Two-speed Oscillator Start-up Enable bit (Start up device with FRC, then switch to user-selected oscillator source)
 
 // FGS
@@ -40,5 +38,4 @@
 
 #include <xc.h>
 
-#endif	/* CONFIG_H */
 

--- a/init.c
+++ b/init.c
@@ -48,30 +48,41 @@ void init_oscillator()
      * http://ww1.microchip.com/downloads/en/DeviceDoc/39700c.pdf
      */
 
+    
+    /*
+     !!! This part was commented out of the code due to an issue with the PIC
+     not switching to the correct clock. The process would fail and default to 
+     FRC. 
+     * 
+     Instead, in the config, the PIC will default to using the Primary Osc. 
+     which fixes the issue.
+     
+     Switching code below is now depreciated.
+     */
     //to unlock NOSC, need to write 0x9A, 0x78, and NOSC to OSCCONH in three
     //consecutive instructions
-    volatile register uint8_t *w = &OSCCONH;
-    register uint8_t x = 0x78;
-    register uint8_t y = 0x9A;
-    //desired NOSC value is lower nibble of z, 3
-    register uint8_t z = 0x73;
+        //    volatile register uint8_t *w = &OSCCONH;
+    //    register uint8_t x = 0x78;
+    //    register uint8_t y = 0x9A;
+    //    //desired NOSC value is lower nibble of z, 3
+    //    register uint8_t z = 0x73;
     //three consecutive writes
-    *w = x;
-    *w = y;
-    *w = z;
+    //    *w = x;
+    //    *w = y;
+    //    *w = z;
     //to perform the clock switch, we need to unlock OSCCONL and write 1 to the
     //lowest bit of OSCCONL. These need to be three consecutive instructions.
     //The two unlock writes are 0x46 and 0x57
-    w = &OSCCONL;
-    x = 0x46;
-    y = 0x57;
-    z = 0x01;
+    //    w = &OSCCONL;
+    //    x = 0x46;
+    //    y = 0x57;
+    //    z = 0x01;
     //three consecutive writes
-    *w = x;
-    *w = y;
-    *w = z;
+    //    *w = x;
+    //    *w = y;
+    //    *w = z;
 
-    //wait until we're running off of the external clock
+    //wait until we're running off of the primary oscillator clock
     while (OSCCONbits.COSC != 0x03) {}
 }
 


### PR DESCRIPTION
Fix the issue with the PIC not switching to the primary clock and being stuck on the Fast Internal Clock.

- In the config file, by default, let PIC use PRCPLL (Primary Oscillator with PLL)
- In the config file, correct configuration pins to the correct board (DSPIC33EP128GP502)
- In the init file, depreciate the old switching code as it is no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/cansw_logger/2)
<!-- Reviewable:end -->
